### PR TITLE
ラッパーの左右マージンはテーマに任せたほうが良さそう

### DIFF
--- a/src/scss/hcb_style.scss
+++ b/src/scss/hcb_style.scss
@@ -23,7 +23,8 @@ $hcbPaddingY: 1.75em;
     position: relative;
     z-index: 0;
     display: block;
-    margin: 2em 0;
+    margin-top: 2em;
+    margin-bottom: 2em;
     padding: 0;
 
     code,


### PR DESCRIPTION
0 固定だと、テーマによっては中央揃えが効かないなどの問題がおこる可能性がある。