### PR TITLE
Chromeでコードラベルが表示されない問題を修正

### DIFF
--- a/class/loos_hcb.php
+++ b/class/loos_hcb.php
@@ -190,7 +190,7 @@ class LOOS_HCB {
 
 		// Code Lang (Default)
 		if ( 'off' === $HCB['show_lang'] ) {
-			$inline_css .= '.hcb_wrap{--hcb--data-label: none;--hcb--btn-offset: 0px;}';
+			$inline_css .= '.hcb_wrap>pre{--hcb--data-label: none;}.hcb_wrap{--hcb--btn-offset: 0px;}';
 		}
 
 		// Font smoothing

--- a/src/scss/_root.scss
+++ b/src/scss/_root.scss
@@ -9,7 +9,7 @@
 	--hcb--pX: 1.5em;
 	--hcb--radius: 3px;
 	--hcb--linenumW: 3.5ch; // It works if the line number is less than or equal to 999
-	--hcb--data-label: attr(data-lang);
+	--hcb--data-label: none;
 	--hcb--btn-offset: 20px;
 
 	// デフォルトカラー

--- a/src/scss/editor/_base.scss
+++ b/src/scss/editor/_base.scss
@@ -141,6 +141,11 @@
 
 
 // Lang Name
+.hcb_wrap > pre,
+.hcb-block {
+	--hcb--data-label: attr(data-lang);
+}
+
 .hcb_wrap > pre::before, // for Classic
 .hcb-block::before {
 	position: absolute;
@@ -182,4 +187,3 @@
 // .hcb-block[data-show-lang="0"]:not([data-file])::before {
 // 	content: none;
 // }
-

--- a/src/scss/front/_base.scss
+++ b/src/scss/front/_base.scss
@@ -166,6 +166,10 @@
 
 
 // Lang Name, File Name
+.hcb_wrap > pre {
+	--hcb--data-label: attr(data-lang);
+}
+
 .hcb_wrap > pre::before {
 	position: absolute;
 	top: 0;


### PR DESCRIPTION
## 概要
- Chromeで言語ラベルが表示されない問題を修正しました。
- `attr(data-lang)`を`:root`ではなく、`data-lang`を持つ要素上で評価するようにしました。
- 言語名の全体非表示設定、ブロック単位の表示切り替え、ファイル名表示の既存挙動を維持しています。

## 確認
- `nr build:css`
- `php -l class/loos_hcb.php`
- `git diff --check`

## 補足
- `vendor/bin/phpcs class/loos_hcb.php`は実行しましたが、今回の変更箇所以外の既存整形エラー4件で失敗しています。

Closes #33
